### PR TITLE
Handle type names and boolean values being used in field names

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -291,4 +291,66 @@ describe("parseMessageDefinition", () => {
       },
     ]);
   });
+
+  it("handles type names for fields", () => {
+    expect(parse(`time time`)).toEqual([
+      {
+        definitions: [
+          {
+            name: "time",
+            type: "time",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+
+    expect(parse(`time time_ref`)).toEqual([
+      {
+        definitions: [
+          {
+            name: "time_ref",
+            type: "time",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+
+    expect(
+      parse(`
+    true true
+    ============
+    MSG: custom/true
+    bool false
+    `),
+    ).toEqual([
+      {
+        definitions: [
+          {
+            name: "true",
+            type: "custom/true",
+            isArray: false,
+            isComplex: true,
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            name: "false",
+            type: "bool",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: "custom/true",
+      },
+    ]);
+  });
 });

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -281,6 +281,68 @@ describe("parseMessageDefinition", () => {
     ]);
   });
 
+  it("handles type names for fields", () => {
+    expect(parse(`time time`)).toEqual([
+      {
+        definitions: [
+          {
+            name: "time",
+            type: "time",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+
+    expect(parse(`time time_ref`)).toEqual([
+      {
+        definitions: [
+          {
+            name: "time_ref",
+            type: "time",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+
+    expect(
+      parse(`
+    true true
+    ============
+    MSG: custom/true
+    bool false
+    `),
+    ).toEqual([
+      {
+        definitions: [
+          {
+            name: "true",
+            type: "custom/true",
+            isArray: false,
+            isComplex: true,
+          },
+        ],
+        name: undefined,
+      },
+      {
+        definitions: [
+          {
+            name: "false",
+            type: "bool",
+            isArray: false,
+            isComplex: false,
+          },
+        ],
+        name: "custom/true",
+      },
+    ]);
+  });
+
   it("parses default values", () => {
     const messageDefinition = `
       int8 a 0

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -7,13 +7,7 @@ const lexer = moo.compile({
   '[': '[',
   ']': ']',
   assignment: /=[^\n]+/,
-  boolType: 'bool',
-  numericType: /byte|char|float32|float64|int8|uint8|int16|uint16|int32|uint32|int64|uint64/,
-  stringType: /string/,
-  timeType: /time|duration/,
-  true: /[Tt]rue/,
-  false: /[Ff]alse/,
-  fieldOrCustomType: /[a-zA-Z_]+(?:\/?[a-zA-Z0-9_]+)?/,
+  fieldOrType: /[a-zA-Z_]+(?:\/?[a-zA-Z0-9_]+)?/,
 });
 %}
 
@@ -33,15 +27,31 @@ main ->
 
 # Types
 
-boolType -> %boolType {% function(d) { return { type: d[0].value } } %}
+boolType -> "bool" {% function(d) { return { type: d[0].value } } %}
 
-numericType -> %numericType {% function(d) { return { type: d[0].value } } %}
+numericType ->
+   ("byte"
+  | "char"
+  | "float32"
+  | "float64"
+  | "int8"
+  | "uint8"
+  | "int16"
+  | "uint16"
+  | "int32"
+  | "uint32"
+  | "int64"
+  | "uint64") {% function(d) { return { type: d[0][0].value } } %}
 
-stringType -> %stringType {% function(d) { return { type: d[0].value } } %}
+stringType -> "string" {% function(d) { return { type: d[0].value } } %}
 
-timeType -> %timeType {% function(d) { return { type: d[0].value } } %}
+timeType -> ("time" | "duration") {% function(d) { return { type: d[0][0].value } } %}
 
-customType -> %fieldOrCustomType {% function(d) { return { type: d[0].value } } %}
+customType -> %fieldOrType {% function(d, _, reject) {
+  const type = d[0].value;
+  if (type.match(/^bool$|^byte$|^char$|^float32$|^float64$|^int8$|^uint8$|^int16$|^uint16$|^int32$|^uint32$|^int64$|^uint64$|^string$|^time$|^duration$/) != undefined) return reject;
+  return { type };
+} %}
 
 arrayType ->
     "[" _ "]" {% function(d) { return { isArray: true } } %}
@@ -50,7 +60,7 @@ arrayType ->
 
 # Fields
 
-field -> %fieldOrCustomType {% function(d, _, reject) {
+field -> %fieldOrType {% function(d, _, reject) {
   const name = d[0].value;
   if (name.match(/^[a-zA-Z](?:_?[a-zA-Z0-9]+)*$/) == undefined) return reject;
   return { name };

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -48,8 +48,9 @@ stringType -> "string" {% function(d) { return { type: d[0].value } } %}
 timeType -> ("time" | "duration") {% function(d) { return { type: d[0][0].value } } %}
 
 customType -> %fieldOrType {% function(d, _, reject) {
+  const PRIMITIVE_TYPES = ["bool", "byte", "char", "float32", "float64", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "string", "time", "duration"];
   const type = d[0].value;
-  if (type.match(/^bool$|^byte$|^char$|^float32$|^float64$|^int8$|^uint8$|^int16$|^uint16$|^int32$|^uint32$|^int64$|^uint64$|^string$|^time$|^duration$/) != undefined) return reject;
+  if (PRIMITIVE_TYPES.includes(type)) return reject;
   return { type };
 } %}
 

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -52,8 +52,9 @@ stringType -> ("wstring" | "string") upperBound:? {% function(d) { return { type
 timeType -> ("time" | "duration") {% function(d) { return { type: d[0][0].value } } %}
 
 customType -> %fieldOrType {% function(d, _, reject) {
+  const PRIMITIVE_TYPES = ["bool", "byte", "char", "float32", "float64", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "string", "wstring", "time", "duration"];
   const type = d[0].value;
-  if (type.match(/^bool$|^byte$|^char$|^float32$|^float64$|^int8$|^uint8$|^int16$|^uint16$|^int32$|^uint32$|^int64$|^uint64$|^w?string$|^time$|^duration$/) != undefined) return reject;
+  if (PRIMITIVE_TYPES.includes(type)) return reject;
   return { type };
 } %}
 


### PR DESCRIPTION
Previously, we relied on the lexer to extract type names. This broke using type names in other places like field names.

These previously failed:

```
time time_ref
time time
true false
```
