### PR TITLE
Remove regexp negative lookbehind

### DIFF
--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -123,7 +123,7 @@ singleQuotedString -> %singleQuotedString {% function(d) {
   // Unescape escaped single quotes
   input = input.replace(/\\'/g, `'`);
   // Escape unescaped double quotes
-  input = input.replace(/(?<!\\)"/g, `\\"`);
+  input = input.replace(/(^|[^\\])"/g, `$1\\"`);
   // Add wrapping double quotes
   input = `"${input}"`;
   return JSON.parse(input);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,9 @@ module.exports = {
   resolve: {
     extensions: [".js", ".ts", ".jsx", ".tsx", ".ne"],
   },
+  optimization: {
+    minimize: false,
+  },
   module: {
     rules: [
       { test: /\.ne$/, loader: "nearley-loader" },


### PR DESCRIPTION
Lookbehinds are not supported by Safari: https://caniuse.com/js-regexp-lookbehind

Also disables minimization for the build to make debugging easier — downstream packagers can decide to minimize during their build if desired.