### PR TITLE
Add test case for integer constant with leading zeros

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -218,6 +218,7 @@ describe("parseMessageDefinition", () => {
       bool someBoolean = 0
       string fooStr = Foo    ${""}
       string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
+      uint64 SMOOTH_MOVE_START    = 0000000000000001 # e.g. kobuki_msgs/VersionInfo
     `;
     const types = parse(messageDefinition);
     expect(types).toEqual([
@@ -258,6 +259,12 @@ describe("parseMessageDefinition", () => {
             type: "string",
             isConstant: true,
             value: '"#comments" are ignored, and leading and trailing whitespace removed',
+          },
+          {
+            name: "SMOOTH_MOVE_START",
+            type: "uint64",
+            isConstant: true,
+            value: 1,
           },
         ],
         name: undefined,


### PR DESCRIPTION
When the parser was converted to Nearley this happened to fix a bug present in rosbag.js: https://github.com/cruise-automation/rosbag.js/issues/98

Add a test case to prevent future accidental regressions.