### PR TITLE
Fix fieldOrType regex to allow numbers in package names

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -360,4 +360,24 @@ describe("parseMessageDefinition", () => {
       },
     ]);
   });
+
+  it("allows numbers in package names", () => {
+    expect(
+      parse(`
+    abc1/Foo2 value0
+    ==========
+    MSG: abc1/Foo2
+    int32 data
+    `),
+    ).toEqual([
+      {
+        definitions: [{ isArray: false, isComplex: true, name: "value0", type: "abc1/Foo2" }],
+        name: undefined,
+      },
+      {
+        definitions: [{ isArray: false, isComplex: false, name: "data", type: "int32" }],
+        name: "abc1/Foo2",
+      },
+    ]);
+  });
 });

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -343,6 +343,29 @@ describe("parseMessageDefinition", () => {
     ]);
   });
 
+  it("allows numbers in package names", () => {
+    expect(
+      parse(
+        `
+    abc1/Foo2 value0
+    ==========
+    MSG: abc1/Foo2
+    int32 data
+    `,
+        { ros2: true },
+      ),
+    ).toEqual([
+      {
+        definitions: [{ isArray: false, isComplex: true, name: "value0", type: "abc1/Foo2" }],
+        name: undefined,
+      },
+      {
+        definitions: [{ isArray: false, isComplex: false, name: "data", type: "int32" }],
+        name: "abc1/Foo2",
+      },
+    ]);
+  });
+
   it("parses default values", () => {
     const messageDefinition = `
       int8 a 0

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -7,7 +7,7 @@ const lexer = moo.compile({
   '[': '[',
   ']': ']',
   assignment: /=[^\n]+/,
-  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/?[a-zA-Z][a-zA-Z0-9_]*)?/,
+  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/[a-zA-Z][a-zA-Z0-9_]*)?/,
 });
 %}
 

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -7,7 +7,7 @@ const lexer = moo.compile({
   '[': '[',
   ']': ']',
   assignment: /=[^\n]+/,
-  fieldOrType: /[a-zA-Z_]+(?:\/?[a-zA-Z0-9_]+)?/,
+  fieldOrType: /[a-zA-Z_][a-zA-Z0-9_]*(?:\/?[a-zA-Z_][a-zA-Z0-9_]*)?/,
 });
 %}
 

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -7,7 +7,7 @@ const lexer = moo.compile({
   '[': '[',
   ']': ']',
   assignment: /=[^\n]+/,
-  fieldOrType: /[a-zA-Z_][a-zA-Z0-9_]*(?:\/?[a-zA-Z_][a-zA-Z0-9_]*)?/,
+  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/?[a-zA-Z][a-zA-Z0-9_]*)?/,
 });
 %}
 

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -11,7 +11,7 @@ const lexer = moo.compile({
   ',': ',',
   '=': '=',
   '<=': '<=',
-  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/?[a-zA-Z][a-zA-Z0-9_]*)?/,
+  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/[a-zA-Z][a-zA-Z0-9_]*)?/,
 });
 %}
 

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -11,7 +11,7 @@ const lexer = moo.compile({
   ',': ',',
   '=': '=',
   '<=': '<=',
-  fieldOrType: /[a-zA-Z_][a-zA-Z0-9_]*(?:\/?[a-zA-Z_][a-zA-Z0-9_]*)?/,
+  fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/?[a-zA-Z][a-zA-Z0-9_]*)?/,
 });
 %}
 

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -11,7 +11,7 @@ const lexer = moo.compile({
   ',': ',',
   '=': '=',
   '<=': '<=',
-  fieldOrType: /[a-zA-Z_]+(?:\/?[a-zA-Z0-9_]+)?/,
+  fieldOrType: /[a-zA-Z_][a-zA-Z0-9_]*(?:\/?[a-zA-Z_][a-zA-Z0-9_]*)?/,
 });
 %}
 


### PR DESCRIPTION
Real-world repro case: `tf2_msgs/LookupTransformResult` (which contains a `tf2_msgs/TF2Error error` field).

<img width="727" alt="image" src="https://user-images.githubusercontent.com/14237/128409670-0afce77b-3ee1-49c0-9560-31b2c205efee.png">
