### PR TITLE
Missing underscore in field definition

### DIFF
--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -63,7 +63,7 @@ arrayType ->
 
 field -> %fieldOrType {% function(d, _, reject) {
   const name = d[0].value;
-  if (name.match(/^[a-zA-Z](?:_?[a-zA-Z0-9]+)*$/) == undefined) return reject;
+  if (name.match(/^[a-zA-Z](?:_?[a-zA-Z0-9_]+)*$/) == undefined) return reject;
   return { name };
 } %}
 


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
None

**Description**
<!-- describe what has changed, and motivation behind those changes -->
I had an issue trying to parse message with this type of field : `string my_field_ # this is my field`
Parser would crash or not parse the field at all.


<!-- link relevant GitHub issues -->
