### PR TITLE
Support unquoted strings for ROS2

### DIFF
--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -441,6 +441,7 @@ describe("parseMessageDefinition", () => {
       string j '"hello"'
       string k "\\"hello\\""
       string l '\\'hello\\''
+      string m hello
     `;
     const types = parse(messageDefinition, { ros2: true });
     expect(types).toEqual([
@@ -527,6 +528,13 @@ describe("parseMessageDefinition", () => {
             name: "l",
             type: "string",
             defaultValue: "'hello'",
+            isArray: false,
+            isComplex: false,
+          },
+          {
+            name: "m",
+            type: "string",
+            defaultValue: "hello",
             isArray: false,
             isComplex: false,
           },

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -239,6 +239,9 @@ describe("parseMessageDefinition", () => {
       string UNQUOTED= Bar
       string UNQUOTEDSPACE = Bar Foo
       string UNQUOTEDSPECIAL = afse_doi@f4!  :834$%G$%
+      string BLANK=
+      string BLANKCOMMENT=# Blank with comment
+    #  string BLANKSPACECOMMENT= # Blank with comment after space
     `;
     const types = parse(messageDefinition, { ros2: true });
     expect(types).toEqual([
@@ -307,6 +310,27 @@ describe("parseMessageDefinition", () => {
             value: "afse_doi@f4!  :834$%G$%",
             valueText: "afse_doi@f4!  :834$%G$%",
           },
+          {
+            name: "BLANK",
+            type: "string",
+            isConstant: true,
+            value: "",
+            valueText: "",
+          },
+          {
+            name: "BLANKCOMMENT",
+            type: "string",
+            isConstant: true,
+            value: "",
+            valueText: "",
+          },
+          // {
+          //   name: "BLANKSPACECOMMENT",
+          //   type: "string",
+          //   isConstant: true,
+          //   value: "",
+          //   valueText: "",
+          // },
         ],
         name: undefined,
       },

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -237,6 +237,8 @@ describe("parseMessageDefinition", () => {
       string FOO_STR = 'Foo'    ${""}
       string EXAMPLE="#comments" # are handled properly
       string UNQUOTED= Bar
+      string UNQUOTEDSPACE = Bar Foo
+      string UNQUOTEDSPECIAL = afse_doi@f4!  :834$%G$%
     `;
     const types = parse(messageDefinition, { ros2: true });
     expect(types).toEqual([
@@ -290,6 +292,20 @@ describe("parseMessageDefinition", () => {
             isConstant: true,
             value: "Bar",
             valueText: 'Bar',
+          },
+          {
+            name: "UNQUOTEDSPACE",
+            type: "string",
+            isConstant: true,
+            value: "Bar Foo",
+            valueText: 'Bar Foo',
+          },
+          {
+            name: "UNQUOTEDSPECIAL",
+            type: "string",
+            isConstant: true,
+            value: "afse_doi@f4!  :834$%G$%",
+            valueText: "afse_doi@f4!  :834$%G$%",
           },
         ],
         name: undefined,

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -327,14 +327,14 @@ describe("parseMessageDefinition", () => {
             type: "bool",
             isConstant: true,
             value: true,
-            valueText: "1", // This should be "True" (https://github.com/foxglove/rosmsg/issues/13)
+            valueText: "True",
           },
           {
             name: "DEAD",
             type: "bool",
             isConstant: true,
             value: false,
-            valueText: "0", // This should be "False" (https://github.com/foxglove/rosmsg/issues/13)
+            valueText: "False",
           },
         ],
         name: undefined,

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -236,6 +236,7 @@ describe("parseMessageDefinition", () => {
       bool SOME_BOOLEAN = 0
       string FOO_STR = 'Foo'    ${""}
       string EXAMPLE="#comments" # are handled properly
+      string UNQUOTED= Bar
     `;
     const types = parse(messageDefinition, { ros2: true });
     expect(types).toEqual([
@@ -282,6 +283,13 @@ describe("parseMessageDefinition", () => {
             isConstant: true,
             value: "#comments",
             valueText: "#comments",
+          },
+          {
+            name: "UNQUOTED",
+            type: "string",
+            isConstant: true,
+            value: "Bar",
+            valueText: 'Bar',
           },
         ],
         name: undefined,

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -107,7 +107,7 @@ constantField -> %fieldOrType {% function(d, _, reject) {
 
 # Constant Values
 
-boolConstantValue -> bool {% function(d) { return { value: d[0], valueText: d[0] ? "1" : "0" } } %}
+boolConstantValue -> bool {% function(d) { return { value: d[0][0], valueText: d[0][1] } } %}
 
 numericConstantValue -> number {% function(d) { return { value: d[0], valueText: String(d[0]) } } %}
 
@@ -115,7 +115,7 @@ stringConstantValue -> (doubleQuotedString | singleQuotedString | unQuotedString
 
 # Default Values
 
-boolDefaultValue -> __ (bool | boolArray) {% function(d) { return { defaultValue: d[1][0] } } %}
+boolDefaultValue -> __ (bool | boolArray) {% function(d) { return { defaultValue: d[1][0][0] } } %}
 
 numericDefaultValue -> __ (number | numberArray) {% function(d) { return { defaultValue: d[1][0] } } %}
 
@@ -132,8 +132,8 @@ numberArray ->
 # Basic Tokens
 
 bool ->
-    ("true" | "True" | "1") {% function(d) { return true } %}
-  | ("false" | "False" | "0") {% function(d) { return false } %}
+    ("true" | "True" | "1") {% function(d) { return [true, d[0][0].text] } %}
+  | ("false" | "False" | "0") {% function(d) { return [false, d[0][0].text] } %}
 
 number -> %number {% function(d) { return parseFloat(d[0].value) } %}
 

--- a/src/ros2.ne
+++ b/src/ros2.ne
@@ -12,7 +12,7 @@ const lexer = moo.compile({
   '=': '=',
   '<=': '<=',
   fieldOrType: /[a-zA-Z][a-zA-Z0-9_]*(?:\/[a-zA-Z][a-zA-Z0-9_]*){0,2}/,
-  plainString: /(?:\S)+/,
+  plainString: /[^#\s\n][^\s\n]*/,
 });
 %}
 
@@ -26,7 +26,10 @@ main ->
   | _ customType arrayType __ field _ comment:? complex {% function(d) { return extend(d) } %}
   | _ boolType __ constantField _ assignment _ boolConstantValue _ comment:? {% function(d) { return extend(d) } %}
   | _ numericType __ constantField _ assignment _ numericConstantValue _ comment:? {% function(d) { return extend(d) } %}
-  | _ stringType __ constantField _ assignment _ stringConstantValue _ comment:? {% function(d) { return extend(d) } %}
+  | _ stringType __ constantField _ assignment _ stringConstantValue:? _ comment:? {% function(d) {
+      d[7] = d[7] || { value: "", valueText: "" };
+      return extend(d)
+      } %}
   | comment {% function(d) { return null } %}
   | blankLine {% function(d) { return null } %}
 


### PR DESCRIPTION
**Public-Facing Changes**
Add unquoted string default and constant support


**Description**
ROS2 message definitions allow for optional quoting of strings, this adds support for these.


Unlike #18, this still uses the lexer & nearly. Unsure of speed impacts.

Should fix foxglove/studio#2035
