### PR TITLE
ROS 1: allow empty string constants

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -252,6 +252,9 @@ describe("parseMessageDefinition", () => {
       float32 baz= \t -32.25
       bool someBoolean = 0
       string fooStr = Foo    ${""}
+      string EMPTY1 =  ${""}
+      string EMPTY2 =
+      string HASH = #
       string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
       uint64 SMOOTH_MOVE_START    = 0000000000000001 # e.g. kobuki_msgs/VersionInfo
     `;
@@ -293,6 +296,27 @@ describe("parseMessageDefinition", () => {
             isConstant: true,
             value: "Foo",
             valueText: "Foo",
+          },
+          {
+            name: "EMPTY1",
+            type: "string",
+            isConstant: true,
+            value: "",
+            valueText: "",
+          },
+          {
+            name: "EMPTY2",
+            type: "string",
+            isConstant: true,
+            value: "",
+            valueText: "",
+          },
+          {
+            name: "HASH",
+            type: "string",
+            isConstant: true,
+            value: "#",
+            valueText: "#",
           },
           {
             name: "EXAMPLE",

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -6,7 +6,7 @@ const lexer = moo.compile({
   comment: /#[^\n]*/,
   '[': '[',
   ']': ']',
-  assignment: /=[^\n]+/,
+  assignment: /=[^\n]*/,
   // Leading underscores are disallowed in field names, while constant names have no explicit restrictions.
   // So we are more lenient in lexing here, and the validation steps below are more strict.
   // See: https://github.com/ros/genmsg/blob/7d8b6ce6f43b6e39ea8261125d270f2d3062356f/src/genmsg/msg_loader.py#L188-L238


### PR DESCRIPTION
**Public-Facing Changes**
Empty string constants are now accepted by the ROS 1 parser.

**Description**
Fixes https://github.com/foxglove/studio/issues/2039 (cc @luisrayas3)