### PR TITLE
ROS 1: Parse int64/uint64 constants as BigInts

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -157,8 +157,8 @@ describe("parseMessageDefinition", () => {
     ]);
   });
 
-  it("parses variable length string array", () => {
-    const types = parse("string[] names");
+  it.each(["string", "int32", "int64"])("parses variable length %s array", (type) => {
+    const types = parse(`${type}[] names`);
     expect(types).toEqual([
       {
         definitions: [
@@ -167,7 +167,7 @@ describe("parseMessageDefinition", () => {
             isArray: true,
             isComplex: false,
             name: "names",
-            type: "string",
+            type,
           },
         ],
         name: undefined,
@@ -257,6 +257,7 @@ describe("parseMessageDefinition", () => {
       string HASH = #
       string EXAMPLE="#comments" are ignored, and leading and trailing whitespace removed
       uint64 SMOOTH_MOVE_START    = 0000000000000001 # e.g. kobuki_msgs/VersionInfo
+      int64 LARGE_VALUE = -9223372036854775807
     `;
     const types = parse(messageDefinition);
     expect(types).toEqual([
@@ -329,8 +330,15 @@ describe("parseMessageDefinition", () => {
             name: "SMOOTH_MOVE_START",
             type: "uint64",
             isConstant: true,
-            value: 1,
+            value: 1n,
             valueText: "0000000000000001",
+          },
+          {
+            name: "LARGE_VALUE",
+            type: "int64",
+            isConstant: true,
+            value: -9223372036854775807n,
+            valueText: "-9223372036854775807",
           },
         ],
         name: undefined,

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -100,7 +100,7 @@ numericConstantValue -> assignment {% function(d, _, reject) {
 bigintConstantValue -> assignment {% function(d, _, reject) {
   const valueText = d[0].split("#")[0].trim();
   try {
-    const value = BigInt(d[0].split("#")[0].trim());
+    const value = BigInt(valueText);
     return { value, valueText };
   } catch {
     return reject;

--- a/src/ros1.ne
+++ b/src/ros1.ne
@@ -18,11 +18,13 @@ const lexer = moo.compile({
 
 main ->
     _ boolType arrayType __ field _ comment:? simple {% function(d) { return extend(d) } %}
+  | _ bigintType arrayType __ field _ comment:? simple {% function(d) { return extend(d) } %}
   | _ numericType arrayType __ field _ comment:? simple {% function(d) { return extend(d) } %}
   | _ stringType arrayType __ field _ comment:? simple {% function(d) { return extend(d) } %}
   | _ timeType arrayType __ field _ comment:? simple {% function(d) { return extend(d) } %}
   | _ customType arrayType __ field _ comment:? complex {% function(d) { return extend(d) } %}
   | _ boolType __ constantField _ boolConstantValue _ comment:? {% function(d) { return extend(d) } %}
+  | _ bigintType __ constantField _ bigintConstantValue _ comment:? {% function(d) { return extend(d) } %}
   | _ numericType __ constantField _ numericConstantValue _ comment:? {% function(d) { return extend(d) } %}
   | _ stringType __ constantField _ stringConstantValue _ comment:? {% function(d) { return extend(d) } %}
   | comment {% function(d) { return null } %}
@@ -32,8 +34,10 @@ main ->
 
 boolType -> "bool" {% function(d) { return { type: d[0].value } } %}
 
-numericType ->
-   ("byte"
+bigintType -> ("int64" | "uint64") {% function(d) { return { type: d[0][0].value } } %}
+
+numericType -> (
+    "byte"
   | "char"
   | "float32"
   | "float64"
@@ -43,8 +47,7 @@ numericType ->
   | "uint16"
   | "int32"
   | "uint32"
-  | "int64"
-  | "uint64") {% function(d) { return { type: d[0][0].value } } %}
+) {% function(d) { return { type: d[0][0].value } } %}
 
 stringType -> "string" {% function(d) { return { type: d[0].value } } %}
 
@@ -92,6 +95,16 @@ numericConstantValue -> assignment {% function(d, _, reject) {
   const valueText = d[0].split("#")[0].trim();
   const value = parseFloat(valueText);
   return !isNaN(value) ? { value, valueText } : reject;
+} %}
+
+bigintConstantValue -> assignment {% function(d, _, reject) {
+  const valueText = d[0].split("#")[0].trim();
+  try {
+    const value = BigInt(d[0].split("#")[0].trim());
+    return { value, valueText };
+  } catch {
+    return reject;
+  }
 } %}
 
 stringConstantValue -> assignment {% function(d) { return { value: d[0], valueText: d[0] } } %}


### PR DESCRIPTION
int64 and uint64 constant values are now JS BigInts, so they can preserve full precision. Similar changes for ROS 2 were made in #18.