### PR TITLE
Add `gendeps2` utility

### DIFF
--- a/bin/gendeps2
+++ b/bin/gendeps2
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require("../dist/gendeps2");

--- a/package.json
+++ b/package.json
@@ -31,8 +31,12 @@
     "dist",
     "src"
   ],
+  "bin": {
+    "gendeps2": "./bin/gendeps2"
+  },
   "scripts": {
     "build": "webpack",
+    "build:gendeps2": "webpack --config webpack.gendeps2.config.js",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "prepack": "yarn build",

--- a/src/gendeps2.ts
+++ b/src/gendeps2.ts
@@ -1,0 +1,119 @@
+import { parse } from "./parse";
+import { readFile, readdir } from "fs/promises";
+import { join, sep } from "path";
+
+async function main() {
+  if (process.argv.length !== 4) {
+    console.error("Usage: gendeps <msgdefs-dir> <msg-file>");
+    process.exit(1);
+  }
+  const msgdefsPath = process.argv[2]!;
+  const msgFile = process.argv[3]!;
+  const msgDefinitionString = await readFile(msgFile, { encoding: "utf8" });
+  const currentPackage = getPackagePath(msgdefsPath, msgFile);
+  const loadedTypes = new Set<string>();
+
+  // parse just the unique set of type names from the .msg file (in order seen, depth first)
+  const complexTypes: string[] = [];
+  const msgDefinitions = parse(msgDefinitionString, { ros2: true, skipTypeFixup: true });
+  for (const msgdef of msgDefinitions) {
+    for (const definition of msgdef.definitions) {
+      if (definition.isComplex === true && !complexTypes.includes(definition.type)) {
+        complexTypes.push(definition.type);
+      }
+    }
+  }
+
+  console.log(msgDefinitionString);
+  while (complexTypes.length > 0) {
+    const typeName = complexTypes.shift()!;
+    const res = await loadDefinitionForType(typeName, msgdefsPath, currentPackage);
+    if (!res) {
+      throw new Error(`Failed to load definition for type ${typeName}`);
+    }
+    const [curTypeName, curMsgDefinitionString] = res;
+    loadedTypes.add(curTypeName);
+    console.log("================================================================================");
+    console.log(`MSG: ${curTypeName}`);
+    console.log(curMsgDefinitionString);
+
+    const curMsgDefinitions = parse(curMsgDefinitionString, { ros2: true, skipTypeFixup: true });
+    for (const msgdef of curMsgDefinitions) {
+      for (const definition of msgdef.definitions) {
+        if (
+          definition.isComplex === true &&
+          !complexTypes.includes(definition.type) &&
+          !loadedTypes.has(definition.type)
+        ) {
+          complexTypes.push(definition.type);
+        }
+      }
+    }
+  }
+
+  // for each type name, find the .msg file in the msgdef root directory
+  // concatenate the .msg file contents to the output
+}
+
+function getPackagePath(msgdefsPath: string, msgFile: string): string {
+  const pathParts = msgdefsPath.split(sep);
+  const msgFileParts = msgFile.split(sep);
+
+  // Remove pathParts from msgFileParts
+  for (const pathPart of pathParts) {
+    if (pathPart !== msgFileParts[0]) {
+      console.log(`${pathPart} !== ${msgFileParts[0]}`);
+      throw new Error(`<msg-file> "${msgFile}" must be under <msgdefs-dir> "${msgdefsPath}"`);
+    }
+    msgFileParts.shift();
+  }
+
+  return msgFileParts[0]!;
+}
+
+async function loadDefinitionForType(
+  typeName: string,
+  rootPath: string,
+  currentPackage: string,
+): Promise<[string, string] | undefined> {
+  if (typeName.includes("/")) {
+    // This is a fully qualified type name. Load the definition from the root path
+    const parts = typeName.split("/");
+    if (parts.length < 2) {
+      throw new Error(`Invalid type name: ${typeName}`);
+    }
+    const packageName = parts[0]!;
+    const typeBaseName = parts[parts.length - 1]!;
+    const filename = `${typeBaseName}.msg`;
+    const contents = await readFileFromPackage(filename, join(rootPath, packageName));
+    return contents != undefined ? [typeName, contents] : undefined;
+  }
+
+  // This is a relative type name. Load the definition from the relative path
+  const filename = `${typeName}.msg`;
+  const fullTypeName = `${currentPackage}/${typeName}`;
+  const contents = await readFileFromPackage(filename, join(rootPath, currentPackage));
+  return contents != undefined ? [fullTypeName, contents] : undefined;
+}
+
+// Recursively search inside a directory for a file with a given name
+async function readFileFromPackage(
+  filename: string,
+  packagePath: string,
+): Promise<string | undefined> {
+  // console.log(`looking for ${filename} in ${packagePath}`);
+  const files = await readdir(packagePath, { withFileTypes: true });
+  for (const file of files) {
+    if (file.isDirectory()) {
+      const contents = await readFileFromPackage(filename, join(packagePath, file.name));
+      if (contents) {
+        return contents;
+      }
+    } else if (file.isFile() && file.name === filename) {
+      return await readFile(join(packagePath, file.name), { encoding: "utf8" });
+    }
+  }
+  return undefined;
+}
+
+void main();

--- a/src/gendeps2.ts
+++ b/src/gendeps2.ts
@@ -1,6 +1,7 @@
-import { parse } from "./parse";
 import { readFile, readdir } from "fs/promises";
 import { join, sep } from "path";
+
+import { parse } from "./parse";
 
 type TypeInformation = {
   fullType: string;
@@ -98,7 +99,7 @@ function getFullTypeFromFilename(filename: string, rootPath: string): string {
   // Remove pathParts from msgFileParts
   for (const pathPart of pathParts) {
     if (pathPart !== filenameParts[0]) {
-      console.log(`${pathPart} !== ${filenameParts[0]}`);
+      console.log(`${pathPart} !== ${filenameParts[0]!}`);
       throw new Error(`<msg-file> "${filename}" must be under <msgdefs-dir> "${rootPath}"`);
     }
     filenameParts.shift();

--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -463,6 +463,7 @@ describe("fixupTypes", () => {
   it("works with an empty list", () => {
     const types: RosMsgDefinition[] = [];
     fixupTypes(types);
+    expect(types).toEqual([]);
   });
 
   it("rewrites type names as expected", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "include": ["./src/**/*.ts"],
+  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "include": ["./src/**/*.ts"],
-  "exclude": ["./src/**/*.test.ts"],
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",

--- a/webpack.gendeps2.config.js
+++ b/webpack.gendeps2.config.js
@@ -1,0 +1,34 @@
+module.exports = {
+  target: "node",
+  mode: "production",
+  entry: "./src/gendeps2.ts",
+  output: {
+    path: require("path").resolve(__dirname, "dist"),
+    filename: "gendeps2.js",
+    libraryTarget: "commonjs2",
+  },
+  devtool: "source-map",
+  resolve: {
+    extensions: [".js", ".ts", ".jsx", ".tsx", ".ne"],
+  },
+  optimization: {
+    minimize: false,
+  },
+  module: {
+    rules: [
+      { test: /\.ne$/, loader: "nearley-loader" },
+      {
+        test: /\.tsx?$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: "ts-loader",
+            options: {
+              configFile: "tsconfig.json",
+            },
+          },
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
**Public-Facing Changes**
- Adds a `gendeps2` command-line utility to convert a given ROS2 `.msg` message definition into the concatenated format containing all dependent message definitions.

**Description**

`gendeps2` is intended to mimic `gendeps --cat` from ROS1. It does not currently do proper ROS2 index parsing and instead relies on recursively searching for matching .msg files in package directories, but this is sufficient for well-formatted repositories such as `rcl_interfaces` and `common_interfaces`.