### PR TITLE
fix: add bin fold into package.json files to make it published

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
+    "bin",
     "dist",
     "src"
   ],


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

Currently, use `pnpm` install  this package will result WARN because bin folder is not publish to registery.

```
 WARN  Failed to create bin at xxxxxxx/node_modules/.bin/gendeps2. The source file at xxxxxxx/node_modules/.pnpm/@foxglove+rosmsg@4.2.1/node_modules/@foxglove/rosmsg/bin/gendeps2 does not exist.
 WARN  Failed to create bin at xxxxxxx/node_modules/.bin/gendeps2. The source file at xxxxxxx/node_modules/.pnpm/@foxglove+rosmsg@4.2.1/node_modules/@foxglove/rosmsg/bin/gendeps2 does not exist.
```

I think the fix is to publish it.
