### PR TITLE
[NOT FOR MERGE] Add uint8 field when ROS 2 message definition is empty.

### DIFF
--- a/src/buildRos2Type.ts
+++ b/src/buildRos2Type.ts
@@ -211,6 +211,24 @@ function normalizeType(type: string): string {
   return type;
 }
 export function buildRos2Type(lines: { line: string }[]): MessageDefinition {
+  // Special case: Empty message definition (e.g. std_msgs/Empty).
+  // Since IDL structs can't be empty, ROS adds a uint8 field in case the
+  // message definition is empty (e.g. std_msgs/Empty):
+  // https://github.com/ros2/rosidl/blob/e3b71ece/rosidl_adapter/rosidl_adapter/resource/struct.idl.em#L101
+  if (lines.length === 0) {
+    return {
+      definitions: [
+        {
+          name: "structure_needs_at_least_one_member",
+          type: "uint8",
+          isComplex: false,
+          isArray: false,
+          isConstant: false,
+        },
+      ],
+    };
+  }
+
   const definitions: MessageDefinitionField[] = [];
   let complexTypeName: string | undefined;
   for (const { line } of lines) {

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -1043,4 +1043,21 @@ string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
       },
     ]);
   });
+
+  it("empty message definition contains at least one member", () => {
+    expect(parse("", { ros2: true })).toEqual([
+      {
+        definitions: [
+          {
+            name: "structure_needs_at_least_one_member",
+            type: "uint8",
+            isComplex: false,
+            isArray: false,
+            isConstant: false,
+          },
+        ],
+        name: undefined,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
### Public-Facing Changes

- Add uint8 field when ROS 2 message definition is empty

### Description
Since IDL does not allow empty structs, ROS adds an extra uint8 field in case the message definition does not contain any fields (e.g. `std_msgs/Empty`). See https://github.com/ros2/rosidl/blob/e3b71ece/rosidl_adapter/rosidl_adapter/resource/struct.idl.em#L101

This patch mirrors this behavior.

Motivation:

Consider the following message definition `empty_test_msgs/msg/EmptyAndInt32`:
```
std_msgs/Empty empty
int32 int_val
```

When publishing this type on a topic
```
ros2 topic pub /empty_and_int32 empty_test_msgs/msg/EmptyAndInt32 int_32_field:\ 2\ 
```

Studio does not parse the message correctly, as it considers the empty field to have a size of 0. 

This patch will fix https://github.com/foxglove/ros-foxglove-bridge/issues/229
