### PR TITLE
5.0.0 version: removes ros2idl support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg",
-  "version": "4.2.2",
+  "version": "5.0.0",
   "description": "Parser for ROS and ROS 2 .msg definitions",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Remove ros2idl support from package.
Ros2idl support is now available in the `@foxglove/ros2idl-parser` npm package.