### PR TITLE
Fix message parsing not taking into account type namespace

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -490,4 +490,70 @@ describe("fixupTypes", () => {
     expect(types[1]!.definitions).toHaveLength(1);
     expect(types[1]!.definitions[0]!.type).toEqual("float64");
   });
+
+  it("does not mixup types with same name but different namespace", () => {
+    const messageDefinition = `
+      MSG: visualization_msgs/Marker
+      int32 a
+
+      ===
+      MSG: aruco_msgs/Marker
+      int32 b
+
+      ===
+      MSG: visualization_msgs/MarkerArray
+      Marker[] a
+
+      ===
+      MSG: aruco_msgs/MarkerArray
+      Marker[] b
+    `;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        name: "visualization_msgs/Marker",
+        definitions: [
+          {
+            type: "int32",
+            isArray: false,
+            name: "a",
+            isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "aruco_msgs/Marker",
+        definitions: [
+          {
+            type: "int32",
+            isArray: false,
+            name: "b",
+            isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "visualization_msgs/MarkerArray",
+        definitions: [
+          {
+            type: "visualization_msgs/Marker",
+            isArray: true,
+            name: "a",
+            isComplex: true,
+          },
+        ],
+      },
+      {
+        name: "aruco_msgs/MarkerArray",
+        definitions: [
+          {
+            type: "aruco_msgs/Marker",
+            isArray: true,
+            name: "b",
+            isComplex: true,
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -746,7 +746,7 @@ describe("parseMessageDefinition", () => {
   it("parses rcl_interfaces/msg/Log", () => {
     const messageDefinition = `##
 ## Severity level constants
-## 
+##
 ## These logging levels follow the Python Standard
 ## https://docs.python.org/3/library/logging.html#logging-levels
 ## And are implemented in rcutils as well
@@ -1040,6 +1040,72 @@ string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
           },
         ],
         name: undefined,
+      },
+    ]);
+  });
+
+  it("does not mixup types with same name but different namespace", () => {
+    const messageDefinition = `
+      MSG: visualization_msgs/msg/Marker
+      int32 a
+
+      ===
+      MSG: aruco_msgs/msg/Marker
+      int32 b
+
+      ===
+      MSG: visualization_msgs/msg/MarkerArray
+      Marker[] a
+
+      ===
+      MSG: aruco_msgs/msg/MarkerArray
+      Marker[] b
+    `;
+    const types = parse(messageDefinition, { ros2: true });
+    expect(types).toEqual([
+      {
+        name: "visualization_msgs/msg/Marker",
+        definitions: [
+          {
+            type: "int32",
+            isArray: false,
+            name: "a",
+            isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "aruco_msgs/msg/Marker",
+        definitions: [
+          {
+            type: "int32",
+            isArray: false,
+            name: "b",
+            isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "visualization_msgs/msg/MarkerArray",
+        definitions: [
+          {
+            type: "visualization_msgs/msg/Marker",
+            isArray: true,
+            name: "a",
+            isComplex: true,
+          },
+        ],
+      },
+      {
+        name: "aruco_msgs/msg/MarkerArray",
+        definitions: [
+          {
+            type: "aruco_msgs/msg/Marker",
+            isArray: true,
+            name: "b",
+            isComplex: true,
+          },
+        ],
       },
     ]);
   });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -167,6 +167,10 @@ function findTypeByName(
       `Expected 1 top level type definition for '${name}' but found ${matches.length}`,
     );
   }
+
+  if (matches.length > 1) {
+    throw new Error(`Cannot unambiguously determine fully-qualified type name for '${name}'`);
+  }
   return matches[0];
 }
 


### PR DESCRIPTION
### Public-Facing Changes

Fix message parsing not taking into account type namespace

### Description
When resolving a relative type, message parsing did not take into account the namespace of the type, resulting in potentially wrong message definitions when there were two types with the same name but different namespaces.

Fixes #39
Resolves FG-5264
