### PR TITLE
Fix `Header` not being resolved to `std_msgs/Header`

### DIFF
--- a/src/parse.ros1.test.ts
+++ b/src/parse.ros1.test.ts
@@ -556,4 +556,71 @@ describe("fixupTypes", () => {
       },
     ]);
   });
+
+  it("correctly resolves Header to std_msgs/Header", () => {
+    const messageDefinition = `
+      StampedBool stamped_bool
+      ================================================================================
+      MSG: custom_msg/StampedBool
+      Header header
+      bool data
+      ================================================================================
+      MSG: std_msgs/Header
+      uint32 seq
+      time stamp
+      string frame_id`;
+    const types = parse(messageDefinition);
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            type: "custom_msg/StampedBool",
+            isArray: false,
+            name: "stamped_bool",
+            isComplex: true,
+          },
+        ],
+      },
+      {
+        name: "custom_msg/StampedBool",
+        definitions: [
+          {
+            type: "std_msgs/Header",
+            isArray: false,
+            name: "header",
+            isComplex: true,
+          },
+          {
+            type: "bool",
+            isArray: false,
+            name: "data",
+            isComplex: false,
+          },
+        ],
+      },
+      {
+        name: "std_msgs/Header",
+        definitions: [
+          {
+            type: "uint32",
+            isArray: false,
+            name: "seq",
+            isComplex: false,
+          },
+          {
+            type: "time",
+            isArray: false,
+            name: "stamp",
+            isComplex: false,
+          },
+          {
+            type: "string",
+            isArray: false,
+            name: "frame_id",
+            isComplex: false,
+          },
+        ],
+      },
+    ]);
+  });
 });

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -154,6 +154,9 @@ function findTypeByName(
     if (name.includes("/")) {
       // Fully-qualified name, match exact
       return typeName === name;
+    } else if (name === "Header") {
+      // Header is a special case, see http://wiki.ros.org/msg#Fields
+      return typeName === `std_msgs/Header`;
     } else if (typeNamespace) {
       // Type namespace is given, create fully-qualified name and match exact
       return typeName === `${typeNamespace}/${name}`;


### PR DESCRIPTION
### Public-Facing Changes

Fix `Header` not being resolved to `std_msgs/Header` (ROS 1)

### Description
This is only the case for ROS1 where `Header` is treated as a special case. See see http://wiki.ros.org/msg#Fields.

> Field types can be:
>
> - built-in type, such as "float32 pan" or "string name"
> - names of Message descriptions defined on their own, such as "geometry_msgs/PoseStamped"
> - fixed- or variable-length arrays (lists) of the above, such as "float32[] ranges" or "Point32[10] points"
> - the special [Header](http://wiki.ros.org/msg#headerSect) type, which maps to std_msgs/Header
>
> When embedding other Message descriptions, the type name may be relative (e.g. "Point32") if it is in the same package; otherwise it must be the full Message type (e.g. "std_msgs/String"). The only exception to this rule is [Header](http://wiki.ros.org/msg#headerSect).

Resolves FG-5667