### PR TITLE
Add provenance attestation when publishing to NPM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     name: push
     runs-on: ubuntu-latest
 
+    permissions:
+      # https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions
+      id-token: write
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -24,8 +28,15 @@ jobs:
       - run: yarn run lint:ci
       - run: yarn run test
 
+      - run: yarn pack
+      - name: Publish to NPM (dry run)
+        # `yarn publish` does not support --provenance
+        run: npm publish foxglove-rosmsg-*.tgz --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
       - name: Publish to NPM
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        run: yarn publish --access public
+        # `yarn publish` does not support --provenance
+        run: npm publish foxglove-rosmsg-*.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
### Changelog
None

### Description

This adds a provenance attestation to the published package so consumers can verify that the package was built on GitHub Actions:
- https://github.blog/2023-04-19-introducing-npm-package-provenance/
- https://docs.npmjs.com/generating-provenance-statements#publishing-packages-with-provenance-via-github-actions

The package will appear like this on npm:

<img src="https://github.blog/wp-content/uploads/2023/04/npm-package-provenance-3.png?w=488&resize=488%2C394" width="250">
