### PR TITLE
ROS2: Normalize `byte` as `uint8` instead of `int8`

### DIFF
--- a/src/buildRos2Type.ts
+++ b/src/buildRos2Type.ts
@@ -200,7 +200,7 @@ function normalizeType(type: string): string {
     case "char":
       return "uint8";
     case "byte":
-      return "int8";
+      return "uint8";
     case "builtin_interfaces/Time":
     case "builtin_interfaces/msg/Time":
       return "time";

--- a/src/parse.ros2.test.ts
+++ b/src/parse.ros2.test.ts
@@ -187,7 +187,7 @@ describe("parseMessageDefinition", () => {
             isArray: false,
             isComplex: false,
             name: "y",
-            type: "int8",
+            type: "uint8",
           },
         ],
         name: undefined,
@@ -803,35 +803,35 @@ uint32 line`;
       {
         definitions: [
           {
-            type: "int8",
+            type: "uint8",
             name: "DEBUG",
             isConstant: true,
             value: 10,
             valueText: "10",
           },
           {
-            type: "int8",
+            type: "uint8",
             name: "INFO",
             isConstant: true,
             value: 20,
             valueText: "20",
           },
           {
-            type: "int8",
+            type: "uint8",
             name: "WARN",
             isConstant: true,
             value: 30,
             valueText: "30",
           },
           {
-            type: "int8",
+            type: "uint8",
             name: "ERROR",
             isConstant: true,
             value: 40,
             valueText: "40",
           },
           {
-            type: "int8",
+            type: "uint8",
             name: "FATAL",
             isConstant: true,
             value: 50,
@@ -1171,6 +1171,28 @@ string<=10[<=5] up_to_five_strings_up_to_ten_characters_each
             isArray: false,
             name: "i",
             isComplex: false,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("handles bounded byte field with default value", () => {
+    // Can be found in /opt/ros/<distro>/share/test_msgs/msg/BoundedSequences.msg
+    const messageDefinition = `
+    byte[<=3] byte_values_default [0, 1, 255]
+    `;
+    const types = parse(messageDefinition, { ros2: true });
+    expect(types).toEqual([
+      {
+        definitions: [
+          {
+            type: "uint8",
+            isArray: true,
+            name: "byte_values_default",
+            isComplex: false,
+            defaultValue: [0, 1, 255],
+            arrayUpperBound: 3,
           },
         ],
       },


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Description

In [ROS2](https://docs.ros.org/en/iron/Concepts/Basic/About-Interfaces.html#field-types), `byte` fields should be treated as `uint8` types:


> | Type name | C++     | Python          | DDS type |
> |-----------|---------|-----------------|----------|
> | byte      | uint8_t | builtins.bytes* | octet    |

Prior to this change we were treating `byte` fields as `int8` which causes errors when parsing a byte field with a default value (e.g. `255`) which is out of the range of a int8. 

