### PR TITLE
ci: update node to 20.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org
 
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
### Changelog
None

### Description
#48 didn't actually work because `--provenance` is not a thing in v16.